### PR TITLE
Update docker.md for SMTP support

### DIFF
--- a/content/docs/self-hosting/docker.md
+++ b/content/docs/self-hosting/docker.md
@@ -44,7 +44,10 @@ On Linux:
 
 ```bash
 docker run --rm -it -p 5200:8080 -p 5089:443 \
-    -e EX_ConnectionStrings__Email=smtps://user:password@smtp.host.com:587 \
+    -e EX_ConnectionStrings__Email=[smtp | smtps]://user:password@smtp.host.com:587 \
+    -e EX_AppMode="[Development | Staging | Production]" \
+    -e EX_BaseURL="[http | https]://example.com" \
+    -e EX_SmtpFrom="John Doe <john.doe@example.com>" \
     -e ASPNETCORE_URLS="https://+;http://+" \
     -e ASPNETCORE_HTTPS_PORT=5001 \
     -e ASPNETCORE_Kestrel__Certificates__Default__Password="password" \
@@ -58,7 +61,10 @@ On PowerShell:
 
 ```powershell
 docker run --rm -it -p 5200:8080 -p 5089:443 `
-    -e EX_ConnectionStrings__Email=smtps://user:password@smtp.host.com:587 `
+    -e EX_ConnectionStrings__Email=[smtp | smtps]://user:password@smtp.host.com:587 \
+    -e EX_AppMode="[Development | Staging | Production]" `
+    -e EX_BaseURL="[http | https]://example.com" `
+    -e EX_SmtpFrom="John Doe <john.doe@example.com>" `
     -e ASPNETCORE_URLS="https://+;http://+" `
     -e ASPNETCORE_HTTPS_PORT=5001 `
     -e ASPNETCORE_Kestrel__Certificates__Default__Password="password" `


### PR DESCRIPTION
I tried to setup Exceptionless with SMTP support on my own machine. Unfortunately, to use ONLY the following environmental parameter does not work (see https://github.com/exceptionless/Exceptionless/issues/1475, more precisely the comment from @gianlucamasini - https://github.com/exceptionless/Exceptionless/issues/1475#issuecomment-1870431404 

```bash
-e EX_ConnectionStrings__Email=smtps://user:password@smtp.host.com:587 \
```

So I had to add the mentioned parameters as well to get the smtp up and running.

```bash
-e EX_ConnectionStrings__Email=[smtp | smtps]://user:password@smtp.host.com:587 \
-e EX_AppMode="[Development | Staging | Production]" \
-e EX_BaseURL="[http | https]://example.com" \
-e EX_SmtpFrom="John Doe <john.doe@example.com>" \
```

For convinience and ease, it might be a good try to add those parameters to your docker guideline as well.